### PR TITLE
Integrate interactive party creation flow

### DIFF
--- a/dnd_master.py
+++ b/dnd_master.py
@@ -3,14 +3,141 @@
 Простое CLI приложение для D&D мастера с использованием OpenAI API
 """
 
+import json
 import os
 import sys
+from typing import Dict, List
+
 from dotenv import load_dotenv
 from openai import OpenAI
 import random
 import yaml
 import re
 from dice_system import dice_roller
+from party_builder import PartyBuilder, PartyMember, PartyValidationError
+
+
+CANDIDATE_LIBRARY: List[Dict[str, object]] = [
+    {
+        "id": "shadow",
+        "pitch": "shadow - скрытный разведчик, терпеливый наблюдатель",
+        "style_focus": ["stealth", "exploration"],
+        "tone_bias": ["neutral", "chaotic"],
+        "member": {
+            "id": "pc_shadow",
+            "name": "Тенар",
+            "role": "Разведчик",
+            "concept": "тихий ловчий",
+            "stats": {"str": 0, "dex": 3, "int": 1, "wit": 2, "charm": 0},
+            "traits": ["скрытный", "терпеливый"],
+            "loadout": ["кинжал", "теневой плащ"],
+            "hp": 10,
+            "tags": ["stealth", "scout"],
+        },
+    },
+    {
+        "id": "warden",
+        "pitch": "warden - внимательный следопыт, преданный защитник",
+        "style_focus": ["exploration", "combat"],
+        "tone_bias": ["lawful", "neutral"],
+        "member": {
+            "id": "pc_warden",
+            "name": "Эллин",
+            "role": "Следопыт",
+            "concept": "сторож границ",
+            "stats": {"str": 1, "dex": 2, "int": 0, "wit": 2, "charm": 0},
+            "traits": ["наблюдательный", "верный"],
+            "loadout": ["лук", "набор следопыта"],
+            "hp": 12,
+            "tags": ["explorer", "guardian"],
+        },
+    },
+    {
+        "id": "silver",
+        "pitch": "silver - утонченный дипломат, чуткий эмпат",
+        "style_focus": ["social"],
+        "tone_bias": ["lawful", "neutral"],
+        "member": {
+            "id": "pc_silver",
+            "name": "Марис",
+            "role": "Дипломат",
+            "concept": "тонкий переговорщик",
+            "stats": {"str": -1, "dex": 1, "int": 2, "wit": 1, "charm": 3},
+            "traits": ["харизматичный", "внимательный"],
+            "loadout": ["шпага", "плащ посредника"],
+            "hp": 9,
+            "tags": ["face", "support"],
+        },
+    },
+    {
+        "id": "ember",
+        "pitch": "ember - решительный дуэлянт, пламенный маг",
+        "style_focus": ["combat"],
+        "tone_bias": ["chaotic", "neutral"],
+        "member": {
+            "id": "pc_ember",
+            "name": "Айрин",
+            "role": "Боевой маг",
+            "concept": "стихийный боец",
+            "stats": {"str": 1, "dex": 1, "int": 2, "wit": 0, "charm": 0},
+            "traits": ["пламенный", "решительный"],
+            "loadout": ["клинок", "огненный фокус"],
+            "hp": 11,
+            "tags": ["combat", "caster"],
+        },
+    },
+    {
+        "id": "sage",
+        "pitch": "sage - любознательный ученый, вдумчивый стратег",
+        "style_focus": ["exploration", "social"],
+        "tone_bias": ["lawful", "neutral"],
+        "member": {
+            "id": "pc_sage",
+            "name": "Калем",
+            "role": "Знаток",
+            "concept": "искатель знаний",
+            "stats": {"str": -1, "dex": 1, "int": 3, "wit": 2, "charm": 0},
+            "traits": ["рассудительный", "вдумчивый"],
+            "loadout": ["том знаний", "компас"],
+            "hp": 9,
+            "tags": ["lore", "planner"],
+        },
+    },
+    {
+        "id": "lotus",
+        "pitch": "lotus - спокойный целитель, мудрый наставник",
+        "style_focus": ["social", "exploration"],
+        "tone_bias": ["lawful", "neutral"],
+        "member": {
+            "id": "pc_lotus",
+            "name": "Сайя",
+            "role": "Целитель",
+            "concept": "миротворец",
+            "stats": {"str": 0, "dex": 0, "int": 2, "wit": 1, "charm": 2},
+            "traits": ["сочувствующий", "сдержанный"],
+            "loadout": ["посох", "лечебные травы"],
+            "hp": 10,
+            "tags": ["healer", "support"],
+        },
+    },
+    {
+        "id": "hammer",
+        "pitch": "hammer - стойкий воин, прямолинейный защитник",
+        "style_focus": ["combat"],
+        "tone_bias": ["lawful", "neutral"],
+        "member": {
+            "id": "pc_hammer",
+            "name": "Бранн",
+            "role": "Воин",
+            "concept": "щит группы",
+            "stats": {"str": 3, "dex": 0, "int": 0, "wit": 1, "charm": -1},
+            "traits": ["несгибаемый", "прямой"],
+            "loadout": ["боевой молот", "щит"],
+            "hp": 14,
+            "tags": ["tank", "frontline"],
+        },
+    },
+]
 
 # Загружаем переменные окружения
 load_dotenv()
@@ -29,6 +156,8 @@ class DnDMaster:
         self.conversation_history = []
         self.world_bible = None
         self.game_rules = None
+        self.party_state_file = "party_state.json"
+        self.party_state = self.load_party_state()
         
         # Загружаем правила игры
         self.load_game_rules()
@@ -64,7 +193,171 @@ class DnDMaster:
         except Exception as e:
             print(f"❌ Ошибка при загрузке правил: {e}")
             self.game_rules = {}
-    
+
+    def load_party_state(self) -> Dict[str, object] | None:
+        """Load stored party state if it exists."""
+        if os.path.exists(self.party_state_file):
+            try:
+                with open(self.party_state_file, 'r', encoding='utf-8') as f:
+                    return json.load(f)
+            except Exception as error:
+                print(f"❌ Не удалось загрузить сохраненную партию: {error}")
+        return None
+
+    def save_party_state(self, payload: Dict[str, object]) -> None:
+        """Persist the created party state to disk."""
+        try:
+            with open(self.party_state_file, 'w', encoding='utf-8') as f:
+                json.dump(payload, f, ensure_ascii=False, indent=2)
+        except Exception as error:
+            print(f"❌ Не удалось сохранить партию: {error}")
+
+    @property
+    def party_initialized(self) -> bool:
+        flags = (
+            self.party_state
+            and self.party_state.get("state_delta", {})
+            .get("flags", {})
+            .get("set", [])
+        )
+        return bool(flags and "party_initialized" in flags)
+
+    def ensure_party_initialized(self) -> None:
+        """Guide the user through party creation if no party exists."""
+        if self.party_initialized:
+            print("Партия уже инициализирована.")
+            return
+
+        try:
+            payload = self._run_party_creation_flow()
+        except KeyboardInterrupt:
+            print("\nСоздание партии прервано пользователем.")
+            sys.exit(0)
+        except PartyValidationError as error:
+            print(f"❌ Ошибка валидации партии: {error}")
+            sys.exit(1)
+
+        if payload:
+            self.party_state = payload
+            self.save_party_state(payload)
+
+    def _run_party_creation_flow(self) -> Dict[str, object]:
+        print("Перед стартом соберем стартовую партию.")
+
+        style = self._prompt_option(
+            "Выбери стиль игры (stealth/combat/social/exploration): ",
+            ["stealth", "combat", "social", "exploration"],
+        )
+        tone = self._prompt_option(
+            "Выбери моральный тон (lawful/neutral/chaotic): ",
+            ["lawful", "neutral", "chaotic"],
+        )
+        taboo = input("Есть ли табу или нежелательные темы? ").strip()
+
+        tags = self._build_preference_tags(style, tone, taboo)
+        candidates = self._select_candidates(style, tone, tags)
+
+        print("\nПредлагаю кандидатов, выбери от одного до трех (id через пробел):")
+        for candidate in candidates:
+            print(candidate["pitch"])
+
+        chosen_ids = self._prompt_candidate_selection([c["id"] for c in candidates])
+
+        builder = PartyBuilder(party_tags=tags[:3])
+        for candidate in candidates:
+            if candidate["id"] in chosen_ids:
+                member = PartyMember(**candidate["member"])  # type: ignore[arg-type]
+                builder.add_member(member)
+
+        payload = builder.build_payload()
+
+        json_text = json.dumps(payload, ensure_ascii=False, indent=2)
+        print(json_text)
+        for line in payload["party_compact"]:
+            print(line)
+
+        return payload
+
+    def _prompt_option(self, prompt: str, options: List[str]) -> str:
+        options_lower = [opt.lower() for opt in options]
+        while True:
+            answer = input(prompt).strip().lower()
+            if answer in options_lower:
+                return answer
+            print(f"Введите одно из: {', '.join(options_lower)}")
+
+    def _prompt_candidate_selection(self, valid_ids: List[str]) -> List[str]:
+        valid = set(valid_ids)
+        while True:
+            raw = input("Ваш выбор: ").strip().lower()
+            choices = [part for part in re.split(r'[\s,;]+', raw) if part]
+            unique = []
+            for item in choices:
+                if item not in unique:
+                    unique.append(item)
+            if 1 <= len(unique) <= 3 and all(choice in valid for choice in unique):
+                return unique
+            print("Нужно выбрать от одного до трех кандидатов из списка.")
+
+    def _build_preference_tags(self, style: str, tone: str, taboo: str) -> List[str]:
+        tags: List[str] = [style.lower(), f"tone_{tone.lower()}"]
+        taboo_tags = self._taboo_to_tags(taboo)
+        for tag in taboo_tags:
+            if tag not in tags:
+                tags.append(tag)
+            if len(tags) == 5:
+                break
+        while len(tags) < 3:
+            tags.append("focus_team")
+        return tags[:5]
+
+    def _taboo_to_tags(self, taboo: str) -> List[str]:
+        if not taboo:
+            return ["no_topics"]
+        chunks = re.split(r'[,;\/\\\s]+', taboo.lower())
+        tags: List[str] = []
+        for chunk in chunks:
+            slug = self._slugify_tag(chunk)
+            if slug and slug not in tags:
+                tags.append(f"no_{slug}")
+            if len(tags) >= 3:
+                break
+        return tags or ["no_topics"]
+
+    def _slugify_tag(self, text: str) -> str:
+        translit_map = {
+            'а': 'a', 'б': 'b', 'в': 'v', 'г': 'g', 'д': 'd', 'е': 'e', 'ё': 'e',
+            'ж': 'zh', 'з': 'z', 'и': 'i', 'й': 'y', 'к': 'k', 'л': 'l', 'м': 'm',
+            'н': 'n', 'о': 'o', 'п': 'p', 'р': 'r', 'с': 's', 'т': 't', 'у': 'u',
+            'ф': 'f', 'х': 'h', 'ц': 'c', 'ч': 'ch', 'ш': 'sh', 'щ': 'sch', 'ъ': '',
+            'ы': 'y', 'ь': '', 'э': 'e', 'ю': 'yu', 'я': 'ya'
+        }
+        result = []
+        for char in text.lower():
+            if char in translit_map:
+                result.append(translit_map[char])
+            elif char.isalnum() and char.isascii():
+                result.append(char)
+        slug = ''.join(result)
+        slug = re.sub(r'[^a-z0-9]+', '', slug)
+        return slug
+
+    def _select_candidates(self, style: str, tone: str, tags: List[str]) -> List[Dict[str, object]]:
+        scored: List[tuple[int, Dict[str, object]]] = []
+        for candidate in CANDIDATE_LIBRARY:
+            score = 0
+            if style in candidate.get("style_focus", []):
+                score += 3
+            if tone in candidate.get("tone_bias", []):
+                score += 2
+            member_tags = candidate.get("member", {}).get("tags", [])  # type: ignore[union-attr]
+            if any(tag in member_tags for tag in tags):
+                score += 1
+            scored.append((score, candidate))
+
+        scored.sort(key=lambda item: (-item[0], item[1]["id"]))
+        return [item[1] for item in scored[:5]]
+
     def initialize_world_bible(self):
         """Инициализация или загрузка Библии мира"""
         bible_file = "world_bible.md"
@@ -266,7 +559,9 @@ class DnDMaster:
         print("Введите ваши действия или вопросы. Для выхода введите 'quit' или 'exit'")
         print("Для просмотра Библии мира введите 'мир' или 'bible'")
         print("-" * 50)
-        
+
+        self.ensure_party_initialized()
+
         while True:
             try:
                 # Получаем ввод от пользователя

--- a/party_builder.py
+++ b/party_builder.py
@@ -1,0 +1,172 @@
+"""Party builder utilities for assembling a small RPG party following strict template rules."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Iterable, Optional
+import json
+
+
+STAT_KEYS: List[str] = ["str", "dex", "int", "wit", "charm"]
+MIN_STAT = -1
+MAX_STAT = 3
+MIN_HP = 8
+MAX_HP = 14
+
+
+class PartyValidationError(ValueError):
+    """Raised when party data violates the template restrictions."""
+
+
+@dataclass
+class PartyMember:
+    """Represents a single party member adhering to the required template."""
+
+    id: str
+    name: str
+    role: str
+    concept: str
+    stats: Dict[str, int]
+    traits: List[str]
+    loadout: List[str]
+    hp: int
+    tags: List[str] = field(default_factory=list)
+
+    def validate(self) -> None:
+        """Validate member data against the template rules."""
+        if not self.id:
+            raise PartyValidationError("Member id must be provided.")
+        if not self.name:
+            raise PartyValidationError("Member name must be provided.")
+        if not self.role:
+            raise PartyValidationError("Member role must be provided.")
+        if not self.concept:
+            raise PartyValidationError("Member concept must be provided.")
+
+        if set(self.stats.keys()) != set(STAT_KEYS):
+            raise PartyValidationError(
+                f"Stats must include exactly the keys: {', '.join(STAT_KEYS)}"
+            )
+
+        for key, value in self.stats.items():
+            if not isinstance(value, int):
+                raise PartyValidationError(f"Stat '{key}' must be an integer.")
+            if value < MIN_STAT or value > MAX_STAT:
+                raise PartyValidationError(
+                    f"Stat '{key}' must be between {MIN_STAT} and {MAX_STAT}."
+                )
+
+        if len(self.traits) != 2:
+            raise PartyValidationError("Member must have exactly 2 traits.")
+        if len(self.loadout) != 2:
+            raise PartyValidationError("Member must have exactly 2 loadout items.")
+        if any(not item for item in self.traits):
+            raise PartyValidationError("Trait descriptions cannot be empty.")
+        if any(not item for item in self.loadout):
+            raise PartyValidationError("Loadout items cannot be empty.")
+
+        if not isinstance(self.hp, int):
+            raise PartyValidationError("HP must be an integer.")
+        if self.hp < MIN_HP or self.hp > MAX_HP:
+            raise PartyValidationError(f"HP must be between {MIN_HP} and {MAX_HP}.")
+
+        if not (0 < len(self.tags) <= 2):
+            raise PartyValidationError("Member must have 1 or 2 tags.")
+        if any(not tag for tag in self.tags):
+            raise PartyValidationError("Tags cannot be empty strings.")
+
+
+class PartyBuilder:
+    """Builds a party payload compliant with the required output schema."""
+
+    MAX_MEMBERS = 3
+
+    def __init__(
+        self,
+        coin: int = 0,
+        rations: int = 0,
+        party_tags: Optional[Iterable[str]] = None,
+    ):
+        self._members: List[PartyMember] = []
+        self.coin = coin
+        self.rations = rations
+        self.party_tags = [tag for tag in (party_tags or []) if tag][:3]
+
+    @property
+    def members(self) -> List[PartyMember]:
+        """Immutable view of the current members list."""
+        return list(self._members)
+
+    def add_member(self, member: PartyMember) -> None:
+        """Add a member to the party after validating constraints."""
+        if len(self._members) >= self.MAX_MEMBERS:
+            raise PartyValidationError("Party already has the maximum number of members.")
+
+        if any(existing.id == member.id for existing in self._members):
+            raise PartyValidationError(f"Member with id '{member.id}' already exists.")
+
+        member.validate()
+        self._members.append(member)
+
+    def is_full(self) -> bool:
+        """Return True if the party reached the maximum size."""
+        return len(self._members) >= self.MAX_MEMBERS
+
+    def clear(self) -> None:
+        """Remove all members from the party."""
+        self._members.clear()
+
+    def build_payload(self) -> Dict[str, object]:
+        """Return the complete payload matching the specified JSON schema."""
+        members_payload = [self._member_to_payload(member) for member in self._members]
+        compact = [self._member_to_compact(member) for member in self._members]
+
+        return {
+            "party": {
+                "max_size": self.MAX_MEMBERS,
+                "members": members_payload,
+                "resources": {"coin": self.coin, "rations": self.rations},
+                "party_tags": self.party_tags,
+            },
+            "state_delta": {
+                "flags": {"set": ["party_initialized"]},
+                "inventory_add": [{"owner": "party", "item_id": "basic_kit"}],
+            },
+            "party_compact": compact,
+        }
+
+    def build_payload_json(self, *, indent: int = 2) -> str:
+        """Return the payload as a JSON string."""
+        payload = self.build_payload()
+        return json.dumps(payload, ensure_ascii=False, indent=indent)
+
+    def _member_to_payload(self, member: PartyMember) -> Dict[str, object]:
+        """Convert a PartyMember to the dictionary required by the schema."""
+        return {
+            "id": member.id,
+            "name": member.name,
+            "role": member.role,
+            "concept": member.concept,
+            "stats": member.stats,
+            "traits": member.traits,
+            "loadout": member.loadout,
+            "hp": member.hp,
+            "tags": member.tags,
+        }
+
+    def _member_to_compact(self, member: PartyMember) -> str:
+        """Create the compact string representation for the member."""
+        key_stat = self._determine_key_stat(member.stats)
+        key_value = member.stats[key_stat]
+        value_str = f"{key_stat.upper()}{key_value:+d}"
+        items = ", ".join(member.loadout)
+        traits = ", ".join(member.traits)
+        return f"{member.name}-{member.role} {value_str} HP{member.hp} - {items}; черты: {traits}"
+
+    @staticmethod
+    def _determine_key_stat(stats: Dict[str, int]) -> str:
+        """Choose the primary stat based on the highest value and predefined priority."""
+        priority = {key: index for index, key in enumerate(STAT_KEYS)}
+        return max(STAT_KEYS, key=lambda key: (stats[key], -priority[key]))
+
+
+__all__ = ["PartyBuilder", "PartyMember", "PartyValidationError"]


### PR DESCRIPTION
## Summary
- prompt the player through the three questions and candidate selection when no party exists
- persist the generated party payload and reuse it on subsequent runs without recreating members
- leverage the party builder utilities to validate picks and print the required JSON plus compact summary

## Testing
- python -m compileall dnd_master.py party_builder.py

------
https://chatgpt.com/codex/tasks/task_e_68e22ebc3ce4832db87cf98535430dda