### PR TITLE
Add scenario-aware party creation flow

### DIFF
--- a/dnd_master.py
+++ b/dnd_master.py
@@ -3,14 +3,18 @@
 Простое CLI приложение для D&D мастера с использованием OpenAI API
 """
 
+import json
 import os
 import sys
+from typing import Dict, List, Optional, Set
+
 from dotenv import load_dotenv
 from openai import OpenAI
 import random
 import yaml
 import re
 from dice_system import dice_roller
+from party_builder import PartyBuilder, PartyMember, PartyValidationError
 
 # Загружаем переменные окружения
 load_dotenv()
@@ -29,6 +33,10 @@ class DnDMaster:
         self.conversation_history = []
         self.world_bible = None
         self.game_rules = None
+        self.party_state_file = "party_state.json"
+        self.party_store = self.load_party_state()
+        self.current_scenario: Optional[str] = None
+        self.party_state: Optional[Dict[str, object]] = None
         
         # Загружаем правила игры
         self.load_game_rules()
@@ -64,7 +72,328 @@ class DnDMaster:
         except Exception as e:
             print(f"❌ Ошибка при загрузке правил: {e}")
             self.game_rules = {}
-    
+
+    def load_party_state(self) -> Dict[str, object]:
+        """Load stored parties for all scenarios, migrating old format if needed."""
+        if os.path.exists(self.party_state_file):
+            try:
+                with open(self.party_state_file, 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+                if isinstance(data, dict) and "scenarios" in data:
+                    scenarios = data.get("scenarios", {})
+                    if isinstance(scenarios, dict):
+                        return {"scenarios": scenarios}
+                if isinstance(data, dict) and "party" in data:
+                    return {"scenarios": {"default": data}}
+            except Exception as error:
+                print(f"❌ Не удалось загрузить сохраненную партию: {error}")
+        return {"scenarios": {}}
+
+    def save_party_state(self) -> None:
+        """Persist all stored scenario parties to disk."""
+        try:
+            with open(self.party_state_file, 'w', encoding='utf-8') as f:
+                json.dump(self.party_store, f, ensure_ascii=False, indent=2)
+        except Exception as error:
+            print(f"❌ Не удалось сохранить партию: {error}")
+
+    @property
+    def party_initialized(self) -> bool:
+        if not isinstance(self.party_state, dict):
+            return False
+        flags = (
+            self.party_state.get("state_delta", {})
+            .get("flags", {})
+            .get("set", [])
+        )
+        return bool(flags and "party_initialized" in flags)
+
+    def ensure_party_initialized(self) -> None:
+        """Guide the user through party creation if no party exists."""
+        self._ensure_scenario_selected()
+        if self.party_initialized:
+            print("Партия уже инициализирована для выбранного сценария.")
+            return
+
+        try:
+            payload = self._run_party_creation_flow()
+        except KeyboardInterrupt:
+            print("\nСоздание партии прервано пользователем.")
+            sys.exit(0)
+        except PartyValidationError as error:
+            print(f"❌ Ошибка валидации партии: {error}")
+            sys.exit(1)
+
+        if payload:
+            self.party_state = payload
+            scenarios = self.party_store.setdefault("scenarios", {})
+            if self.current_scenario:
+                scenarios[self.current_scenario] = payload
+            self.save_party_state()
+            print("\nПартия готова. Ведущий может начинать первую сцену.")
+
+    def _run_party_creation_flow(self) -> Dict[str, object]:
+        scenario_label = self.current_scenario or "новый сценарий"
+        print(f"Создаем стартовую команду для сценария: {scenario_label}")
+
+        party_size = self._prompt_party_size()
+        builder = PartyBuilder()
+        existing_ids: Set[str] = set()
+
+        for index in range(1, party_size + 1):
+            print(f"\nПерсонаж {index} из {party_size}:")
+            member = self._collect_member_data(index, existing_ids)
+            builder.add_member(member)
+            existing_ids.add(member.id)
+
+        coin = self._prompt_optional_int(
+            "Сколько монет у партии? (по умолчанию 0): ",
+            minimum=0,
+            default=0,
+        )
+        rations = self._prompt_optional_int(
+            "Сколько пайков у партии? (по умолчанию 0): ",
+            minimum=0,
+            default=0,
+        )
+        party_tags = self._prompt_party_tags()
+
+        builder.coin = coin
+        builder.rations = rations
+        builder.party_tags = party_tags
+
+        payload = builder.build_payload()
+
+        json_text = json.dumps(payload, ensure_ascii=False, indent=2)
+        print(json_text)
+        for line in payload["party_compact"]:
+            print(line)
+
+        return payload
+
+    def _ensure_scenario_selected(self) -> None:
+        if self.current_scenario:
+            return
+
+        scenarios = self.party_store.get("scenarios", {})
+        scenario_names = list(scenarios.keys())
+        if scenario_names:
+            print("\nДоступные сценарии:")
+            for idx, name in enumerate(scenario_names, start=1):
+                print(f"  {idx}. {name}")
+
+        prompt = (
+            "Введите название сценария или номер из списка: "
+            if scenario_names
+            else "Введите название нового сценария: "
+        )
+
+        while True:
+            choice = input(prompt).strip()
+            if not choice:
+                print("Название сценария не может быть пустым.")
+                continue
+
+            if scenario_names and choice.isdigit():
+                index = int(choice)
+                if 1 <= index <= len(scenario_names):
+                    self.current_scenario = scenario_names[index - 1]
+                    break
+                print("Укажите корректный номер из списка.")
+                continue
+
+            self.current_scenario = choice
+            break
+
+        if self.current_scenario in scenarios:
+            stored = scenarios[self.current_scenario]
+            if isinstance(stored, dict):
+                self.party_state = stored
+
+    def _prompt_party_size(self) -> int:
+        while True:
+            raw = input("Сколько персонажей будет в этом сценарии? (1-3): ").strip()
+            if not raw:
+                print("Нужно ввести число от 1 до 3.")
+                continue
+            if raw.isdigit():
+                value = int(raw)
+                if 1 <= value <= 3:
+                    return value
+            print("Количество персонажей должно быть от 1 до 3.")
+
+    def _collect_member_data(self, index: int, existing_ids: Set[str]) -> PartyMember:
+        name = self._prompt_non_empty("Имя персонажа: ")
+        role = self._prompt_non_empty("Роль персонажа: ")
+        concept = self._prompt_non_empty("Коротко о концепте: ")
+
+        stats: Dict[str, int] = {}
+        stat_order = [
+            ("str", "Сила"),
+            ("dex", "Ловкость"),
+            ("int", "Интеллект"),
+            ("wit", "Сообразительность"),
+            ("charm", "Обаяние"),
+        ]
+        for key, label in stat_order:
+            stats[key] = self._prompt_int(
+                f"{label} ({-1} до {3}): ",
+                minimum=-1,
+                maximum=3,
+            )
+
+        hp = self._prompt_int("HP (8-14): ", minimum=8, maximum=14)
+
+        traits = self._prompt_fixed_list(
+            "Укажи две черты характера (через запятую): ",
+            expected_count=2,
+        )
+        loadout = self._prompt_fixed_list(
+            "Укажи два предмета стартового снаряжения (через запятую): ",
+            expected_count=2,
+        )
+        tags = self._prompt_tags(
+            "Укажи 1-2 тега персонажа (через запятую): ",
+            minimum=1,
+            maximum=2,
+        )
+
+        member_id = self._generate_member_id(name, existing_ids, index)
+
+        return PartyMember(
+            id=member_id,
+            name=name,
+            role=role,
+            concept=concept,
+            stats=stats,
+            traits=traits,
+            loadout=loadout,
+            hp=hp,
+            tags=tags,
+        )
+
+    def _prompt_non_empty(self, prompt: str) -> str:
+        while True:
+            value = input(prompt).strip()
+            if value:
+                return value
+            print("Поле не может быть пустым.")
+
+    def _prompt_int(
+        self,
+        prompt: str,
+        *,
+        minimum: Optional[int] = None,
+        maximum: Optional[int] = None,
+    ) -> int:
+        while True:
+            raw = input(prompt).strip()
+            try:
+                value = int(raw)
+            except ValueError:
+                print("Введите целое число.")
+                continue
+            if minimum is not None and value < minimum:
+                print(f"Число не может быть меньше {minimum}.")
+                continue
+            if maximum is not None and value > maximum:
+                print(f"Число не может быть больше {maximum}.")
+                continue
+            return value
+
+    def _prompt_optional_int(
+        self,
+        prompt: str,
+        *,
+        minimum: Optional[int] = None,
+        maximum: Optional[int] = None,
+        default: int = 0,
+    ) -> int:
+        while True:
+            raw = input(prompt).strip()
+            if not raw:
+                return default
+            try:
+                value = int(raw)
+            except ValueError:
+                print("Введите целое число или оставьте строку пустой.")
+                continue
+            if minimum is not None and value < minimum:
+                print(f"Число не может быть меньше {minimum}.")
+                continue
+            if maximum is not None and value > maximum:
+                print(f"Число не может быть больше {maximum}.")
+                continue
+            return value
+
+    def _prompt_fixed_list(self, prompt: str, *, expected_count: int) -> List[str]:
+        while True:
+            raw = input(prompt).strip()
+            items = [item.strip() for item in re.split(r'[;,/]+', raw) if item.strip()]
+            if len(items) == expected_count:
+                return items
+            print(f"Нужно указать ровно {expected_count} элемента(ов).")
+
+    def _prompt_tags(
+        self,
+        prompt: str,
+        *,
+        minimum: int,
+        maximum: int,
+    ) -> List[str]:
+        while True:
+            raw = input(prompt).strip()
+            items = [item.strip() for item in re.split(r'[;,]+', raw) if item.strip()]
+            if minimum <= len(items) <= maximum:
+                return items
+            print(f"Нужно указать от {minimum} до {maximum} тегов.")
+
+    def _prompt_party_tags(self) -> List[str]:
+        prompt = (
+            "Опиши стиль партии тегами (до 3, через запятую, по умолчанию adventure): "
+        )
+        while True:
+            raw = input(prompt).strip()
+            if not raw:
+                return ["adventure"]
+            tags = [item.strip() for item in re.split(r'[;,]+', raw) if item.strip()]
+            if 1 <= len(tags) <= 3:
+                return tags
+            print("Можно указать от 1 до 3 тегов.")
+
+    def _generate_member_id(
+        self,
+        name: str,
+        existing_ids: Set[str],
+        index: int,
+    ) -> str:
+        base = self._slugify_tag(name) or f"pc_{index}"
+        candidate = f"pc_{base}" if not base.startswith("pc_") else base
+        suffix = 1
+        final_id = candidate
+        while final_id in existing_ids:
+            suffix += 1
+            final_id = f"{candidate}_{suffix}"
+        return final_id
+
+    def _slugify_tag(self, text: str) -> str:
+        translit_map = {
+            'а': 'a', 'б': 'b', 'в': 'v', 'г': 'g', 'д': 'd', 'е': 'e', 'ё': 'e',
+            'ж': 'zh', 'з': 'z', 'и': 'i', 'й': 'y', 'к': 'k', 'л': 'l', 'м': 'm',
+            'н': 'n', 'о': 'o', 'п': 'p', 'р': 'r', 'с': 's', 'т': 't', 'у': 'u',
+            'ф': 'f', 'х': 'h', 'ц': 'c', 'ч': 'ch', 'ш': 'sh', 'щ': 'sch', 'ъ': '',
+            'ы': 'y', 'ь': '', 'э': 'e', 'ю': 'yu', 'я': 'ya'
+        }
+        result = []
+        for char in text.lower():
+            if char in translit_map:
+                result.append(translit_map[char])
+            elif char.isalnum() and char.isascii():
+                result.append(char)
+        slug = ''.join(result)
+        slug = re.sub(r'[^a-z0-9]+', '', slug)
+        return slug
+
     def initialize_world_bible(self):
         """Инициализация или загрузка Библии мира"""
         bible_file = "world_bible.md"
@@ -266,7 +595,9 @@ class DnDMaster:
         print("Введите ваши действия или вопросы. Для выхода введите 'quit' или 'exit'")
         print("Для просмотра Библии мира введите 'мир' или 'bible'")
         print("-" * 50)
-        
+
+        self.ensure_party_initialized()
+
         while True:
             try:
                 # Получаем ввод от пользователя

--- a/party_builder.py
+++ b/party_builder.py
@@ -1,0 +1,172 @@
+"""Party builder utilities for assembling a small RPG party following strict template rules."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Iterable, Optional
+import json
+
+
+STAT_KEYS: List[str] = ["str", "dex", "int", "wit", "charm"]
+MIN_STAT = -1
+MAX_STAT = 3
+MIN_HP = 8
+MAX_HP = 14
+
+
+class PartyValidationError(ValueError):
+    """Raised when party data violates the template restrictions."""
+
+
+@dataclass
+class PartyMember:
+    """Represents a single party member adhering to the required template."""
+
+    id: str
+    name: str
+    role: str
+    concept: str
+    stats: Dict[str, int]
+    traits: List[str]
+    loadout: List[str]
+    hp: int
+    tags: List[str] = field(default_factory=list)
+
+    def validate(self) -> None:
+        """Validate member data against the template rules."""
+        if not self.id:
+            raise PartyValidationError("Member id must be provided.")
+        if not self.name:
+            raise PartyValidationError("Member name must be provided.")
+        if not self.role:
+            raise PartyValidationError("Member role must be provided.")
+        if not self.concept:
+            raise PartyValidationError("Member concept must be provided.")
+
+        if set(self.stats.keys()) != set(STAT_KEYS):
+            raise PartyValidationError(
+                f"Stats must include exactly the keys: {', '.join(STAT_KEYS)}"
+            )
+
+        for key, value in self.stats.items():
+            if not isinstance(value, int):
+                raise PartyValidationError(f"Stat '{key}' must be an integer.")
+            if value < MIN_STAT or value > MAX_STAT:
+                raise PartyValidationError(
+                    f"Stat '{key}' must be between {MIN_STAT} and {MAX_STAT}."
+                )
+
+        if len(self.traits) != 2:
+            raise PartyValidationError("Member must have exactly 2 traits.")
+        if len(self.loadout) != 2:
+            raise PartyValidationError("Member must have exactly 2 loadout items.")
+        if any(not item for item in self.traits):
+            raise PartyValidationError("Trait descriptions cannot be empty.")
+        if any(not item for item in self.loadout):
+            raise PartyValidationError("Loadout items cannot be empty.")
+
+        if not isinstance(self.hp, int):
+            raise PartyValidationError("HP must be an integer.")
+        if self.hp < MIN_HP or self.hp > MAX_HP:
+            raise PartyValidationError(f"HP must be between {MIN_HP} and {MAX_HP}.")
+
+        if not (0 < len(self.tags) <= 2):
+            raise PartyValidationError("Member must have 1 or 2 tags.")
+        if any(not tag for tag in self.tags):
+            raise PartyValidationError("Tags cannot be empty strings.")
+
+
+class PartyBuilder:
+    """Builds a party payload compliant with the required output schema."""
+
+    MAX_MEMBERS = 3
+
+    def __init__(
+        self,
+        coin: int = 0,
+        rations: int = 0,
+        party_tags: Optional[Iterable[str]] = None,
+    ):
+        self._members: List[PartyMember] = []
+        self.coin = coin
+        self.rations = rations
+        self.party_tags = [tag for tag in (party_tags or []) if tag][:3]
+
+    @property
+    def members(self) -> List[PartyMember]:
+        """Immutable view of the current members list."""
+        return list(self._members)
+
+    def add_member(self, member: PartyMember) -> None:
+        """Add a member to the party after validating constraints."""
+        if len(self._members) >= self.MAX_MEMBERS:
+            raise PartyValidationError("Party already has the maximum number of members.")
+
+        if any(existing.id == member.id for existing in self._members):
+            raise PartyValidationError(f"Member with id '{member.id}' already exists.")
+
+        member.validate()
+        self._members.append(member)
+
+    def is_full(self) -> bool:
+        """Return True if the party reached the maximum size."""
+        return len(self._members) >= self.MAX_MEMBERS
+
+    def clear(self) -> None:
+        """Remove all members from the party."""
+        self._members.clear()
+
+    def build_payload(self) -> Dict[str, object]:
+        """Return the complete payload matching the specified JSON schema."""
+        members_payload = [self._member_to_payload(member) for member in self._members]
+        compact = [self._member_to_compact(member) for member in self._members]
+
+        return {
+            "party": {
+                "max_size": self.MAX_MEMBERS,
+                "members": members_payload,
+                "resources": {"coin": self.coin, "rations": self.rations},
+                "party_tags": self.party_tags,
+            },
+            "state_delta": {
+                "flags": {"set": ["party_initialized"]},
+                "inventory_add": [{"owner": "party", "item_id": "basic_kit"}],
+            },
+            "party_compact": compact,
+        }
+
+    def build_payload_json(self, *, indent: int = 2) -> str:
+        """Return the payload as a JSON string."""
+        payload = self.build_payload()
+        return json.dumps(payload, ensure_ascii=False, indent=indent)
+
+    def _member_to_payload(self, member: PartyMember) -> Dict[str, object]:
+        """Convert a PartyMember to the dictionary required by the schema."""
+        return {
+            "id": member.id,
+            "name": member.name,
+            "role": member.role,
+            "concept": member.concept,
+            "stats": member.stats,
+            "traits": member.traits,
+            "loadout": member.loadout,
+            "hp": member.hp,
+            "tags": member.tags,
+        }
+
+    def _member_to_compact(self, member: PartyMember) -> str:
+        """Create the compact string representation for the member."""
+        key_stat = self._determine_key_stat(member.stats)
+        key_value = member.stats[key_stat]
+        value_str = f"{key_stat.upper()}{key_value:+d}"
+        items = ", ".join(member.loadout)
+        traits = ", ".join(member.traits)
+        return f"{member.name}-{member.role} {value_str} HP{member.hp} - {items}; черты: {traits}"
+
+    @staticmethod
+    def _determine_key_stat(stats: Dict[str, int]) -> str:
+        """Choose the primary stat based on the highest value and predefined priority."""
+        priority = {key: index for index, key in enumerate(STAT_KEYS)}
+        return max(STAT_KEYS, key=lambda key: (stats[key], -priority[key]))
+
+
+__all__ = ["PartyBuilder", "PartyMember", "PartyValidationError"]


### PR DESCRIPTION
## Summary
- ask the host to pick or name a scenario before starting the session and reuse stored parties per scenario
- collect the desired party size, then prompt for each member's full sheet and validate with the existing party builder
- save the assembled payload under the scenario, print the required JSON plus compact summary, and announce that the first scene can begin

## Testing
- python -m compileall dnd_master.py party_builder.py

------
https://chatgpt.com/codex/tasks/task_e_68e22ebc3ce4832db87cf98535430dda